### PR TITLE
Match the same query args on websocket as on main route

### DIFF
--- a/src/socket.ts
+++ b/src/socket.ts
@@ -35,11 +35,10 @@ socket.on('qido-request', async (data) => {
 
 socket.on('wadouri-request', async (data) => {
   logger.info('websocket wadouri request received, fetching metadata now...');
-  const {
-    studyUID, seriesUID, objectUID, studyInstanceUid, seriesInstanceUid, sopInstanceUid
-  } = data.query;
-
   if (data) {
+    const {
+      studyUID, seriesUID, objectUID, studyInstanceUid, seriesInstanceUid, sopInstanceUid
+    } = data.query;
     try {
       const rsp = await doWadoUri({
         studyInstanceUid: studyInstanceUid ?? studyUID,


### PR DESCRIPTION
If you called /wadouri it uses studyURI, seriesURI and objectURI, but if you called the same thing via the websocket it uses studyInstanceUri etc.

This change still allows the studyInstanceUri query arguments for backward compatibility, but also allows for the query params to match the main route into wadouri