### PR TITLE
Wait for DIMSE fetched data to be present on disk

### DIFF
--- a/src/utils/fileHelper.ts
+++ b/src/utils/fileHelper.ts
@@ -26,6 +26,23 @@ export async function fileExists(pathname: string): Promise<boolean> {
   }
 }
 
+export async function waitForFile(pathname: string, maxRetries = 3, delay = 100) {
+  let lastError: any;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      if (await fileExists(pathname)) {
+        return true;
+      } else {
+        throw new Error(`file not found: ${pathname}`);
+      }
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw lastError;
+}
+
 export async function clearCache() {
   const storagePath = config.get(ConfParams.STORAGE_PATH) as string;
   const retention = config.get(ConfParams.CACHE_RETENTION) as number;


### PR DESCRIPTION
Fixes #143 
Some os/filesystems may not have fully written DIMSE fetched data to disk when the request completes. This waits for the data to be present, and will throw if data not present after a specified timeout.